### PR TITLE
Stop wait for hanging forever if job not in queue

### DIFF
--- a/cluster/queue.py
+++ b/cluster/queue.py
@@ -191,9 +191,9 @@ class Queue(object):
             else:
                 if isinstance(job, self._Job):
                     job = job.id
+                not_found = 0
                 while True:
                     self.update()
-                    not_found = 0
                     # Allow two seconds to elapse before job is found in queue,
                     # if it is not in the queue by then, raise exception.
                     if job not in self.jobs:


### PR DESCRIPTION
It appears that the desired behavior here was to
throw an Exception if the job could not be found
in the queue two times in a row (after _not_found_
reached 3). But because _not_found_ was reset to
zero every time in the loop, this condition was
never reached. So if the job was not in the queue,
wait would hang infinitely. This change moves
_not_found = 0_ outside of the loop.
