### PR TITLE
Fixes #17 and fixes #33

### DIFF
--- a/fyrd/job.py
+++ b/fyrd/job.py
@@ -1,7 +1,7 @@
 """
 Class and methods to handle Job submission.
 
-Last modified: 2016-10-30 18:02
+Last modified: 2016-10-31 23:31
 """
 import os
 import sys
@@ -184,7 +184,6 @@ class Job(object):
                 name = command.split(' ')[0].split('/')[-1]
 
         # Make sure name not in queue
-        self.queue.update()
         names     = [i.name.split('.')[0] for i in self.queue]
         namecnt   = len([i for i in names if i == name])
         self.name = '{}.{}'.format(name, namecnt)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,3 +41,6 @@ def test_profile():
 def test_delete():
     """Delete the temp config file."""
     os.remove(os.path.abspath('conftest'))
+    fyrd.config_file.CONFIG_FILE = os.path.abspath(
+        os.path.expanduser('~/.fyrd')
+    )

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -22,7 +22,7 @@ def write_to_file(string, file):
 def test_job_creation():
     """Make a job and print it."""
     job = fyrd.Job('echo hi', cores=2, time='00:02:00', mem='2000',
-                      threads=4, profile='default', **kwds)
+                   threads=4, profile='default', **kwds)
     assert job.qtype == env
     return job
 
@@ -57,6 +57,7 @@ def test_function_submission():
     """Submit a function."""
     job = fyrd.Job(write_to_file, ('42', 'bobfile'), **kwds)
     job.submit()
+    assert job.kwargs['partition'] == 'hbfraser'
     code, stdout, stderr = job.get()
     sys.stdout.write('{};\nSTDOUT: {}\nSTDERR: {}\n'
                      .format(code, stdout, stderr))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -57,7 +57,6 @@ def test_function_submission():
     """Submit a function."""
     job = fyrd.Job(write_to_file, ('42', 'bobfile'), **kwds)
     job.submit()
-    assert job.kwargs['partition'] == 'hbfraser'
     code, stdout, stderr = job.get()
     sys.stdout.write('{};\nSTDOUT: {}\nSTDERR: {}\n'
                      .format(code, stdout, stderr))


### PR DESCRIPTION
Fixed:
- Problem with parsing exitcodes: '0' was being skipped when already an
integer as fails `if exitcode` test.
- Fixed bug with sacct parsing that made sacct parsing always fail
- Fixed bug with tests that made configuration fail to be reactivated
after test_config ran
- Made acct debug logging more verbose
- Made the Queue class not update on method access as before, which
means the user now has to run Queue.update() to get the latest
information, not just Queue as before. This provides a dramatic speedup
as queue parsing is costly.