### PR TITLE
Makes output handling more robust and alters testing.

### DIFF
--- a/fyrd/run.py
+++ b/fyrd/run.py
@@ -1,7 +1,7 @@
 """
 File management and execution functions.
 
-Last modified: 2016-10-30 18:30
+Last modified: 2016-11-01 15:49
 """
 import os
 import re
@@ -149,7 +149,7 @@ with open('{pickle_file}', 'rb') as fin:
                          'all required modules locally, this may take some '
                          'time\\n')
         try:
-            cmd("cat ~/.python_module_list.txt | xargs pip{{}} install --user"
+            cmd("cat ~/.{name}.module_list | xargs pip{{}} install --user"
                 .format(ver))
         except:
             pass
@@ -279,7 +279,7 @@ def cmd(command, args=None, stdout=None, stderr=None, tries=1):
         try:
             pp = Popen(args, shell=True, universal_newlines=True,
                        stdout=PIPE, stderr=PIPE)
-        except FileNotFountError:
+        except FileNotFoundError:
             logme.log('{} does not exist'.format(command), 'critical')
             raise
         out, err = pp.communicate()

--- a/tests/local_queue.py
+++ b/tests/local_queue.py
@@ -21,22 +21,22 @@ def test_job_creation():
     return job
 
 
-def test_job_execution():
+def test_job_execution(autoclean=True):
     """Run a job"""
     fyrd.queue.MODE = 'local'
     job = test_job_creation()
     job.submit()
-    code, stdout, stderr = job.get()
-    assert code == 0
-    assert stdout == 'hi\n'
-    assert stderr == ''
+    out = job.get(autoclean)
+    assert job.exitcode == 0
+    assert out == 'hi\n'
+    assert job.stderr == ''
     return job
 
 
 def test_job_cleaning():
     """Delete intermediate files."""
     fyrd.queue.MODE = 'local'
-    job = test_job_execution()
+    job = test_job_execution(False)
     job.clean()
     assert 'echo.cluster' not in os.listdir('.')
     return 0
@@ -48,10 +48,11 @@ def test_function_submission():
     fyrd.queue.MODE = 'local'
     job = fyrd.Job(write_to_file, ('42', 'bobfile'))
     job.submit()
-    code, stdout, stderr = job.get()
-    assert code == 0
-    assert stdout == '\n'
-    if stderr != '':
+    out = job.get()
+    assert job.exitcode == 0
+    assert job.out == 0
+    assert job.stdout == '\n'
+    if job.stderr != '':
         sys.stderr.write('STDERR should be empty, but contains:\n')
         sys.stderr.write(stderr)
         failed = True

--- a/tests/pyenv_tests.sh
+++ b/tests/pyenv_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# To use this code, create virtualenvs with pyenv that begin with fyrd_
+# Tests will be run in all of these virtualenvs
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+versions=$(pyenv versions | grep " fyrd" | sed 's/\*//g' | sed 's/^ \+//g' | sed 's/ .*//g')
+
+for i in ${versions[@]}; do
+  echo "Testing in $i"
+  pyenv shell $i
+  pip uninstall -y fyrd
+  pip install .
+  pip install -r tests/test_requirements.txt
+  if [ -e 'tests' ]; then
+    python tests/run_tests.py
+  else
+    python run_tests.py
+  fi
+done

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,0 +1,4 @@
+dill>=0.2.5
+fyrd>=0.6.1b3
+pytest>=3.0.3
+pandas>=0.18.0


### PR DESCRIPTION
This represents a significant API break for the handling of outputs.

Previously, `Job.get()` would return `(exitcode, stdout, stderr)`, not it just returns the output, which is either the function return value, or the contents of `STDOUT`. All other variables (`.out`, `.stdout`, `.stderr`, and `exitcode`) are saved and the temp files cleaned up by default after `get()` completes.

I think this makes more intuitive sense than the prior approach, it should also be more stable.

The one potential downside is that very large return values get loaded into memory by default. That can be avoided by using `wait()`.