### PR TITLE
Implemented limited version testing

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,17 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.py"
+exclude_paths:
+- tests/
+- docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "nightly"
 
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install -r tests/test_requirements.txt"
 
 # Run py.test and also a separate local queue test
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install: "pip install -r tests/test_requirements.txt"
 # Run py.test and also a separate local queue test
 script:
   - coverage run --source=fyrd tests/run_tests.py
+  - coverage xml
+  - python-codacy-coverage -r coverage.xml
 
 # Code Climate
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,9 @@ install: "pip install -r requirements.txt"
 
 # Run py.test and also a separate local queue test
 script:
-  - py.test
-  - python tests/local_queue.py
+  - coverage run --source=fyrd tests/run_tests.py
+
+# Code Climate
+addons:
+  code_climate:
+    repo_token: b3a6260dfcca35803c0df8bb5dbb89eeb88fd288853d164979c6b352438d26f8

--- a/tests/pyenv_tests.sh
+++ b/tests/pyenv_tests.sh
@@ -23,17 +23,29 @@ if [[ $? > 0 ]]; then
   exit 50
 fi
 
+# Command line argument parsing
+limited=0
+loc=''
+for i in $@; do
+  case $i in
+    '--limited' ) limited=1;;
+    '-l'        ) loc='--local';;
+    '--local'   ) loc='--local';;
+  esac
+done
 
 # Versions to test
-if [[ $1 == '--limited' ]]; then
+if [[ $limited == 1 ]]; then
   versions=('2.7.10' '3.3.0' '3.5.2')
 else
   versions=('2.7.10' '2.7.11' '2.7.12' '3.3.0' '3.4.0' '3.5.2' '3.6-dev' '3.7-dev')
 fi
 anaconda_versions=(anaconda2-4.1.1, anaconda3-4.1.1)
+
+# Starting string for virtualenvs
 build_string="fyrd_$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
 
-# Delete
+# Delete virtualenvs on exit
 function on_exit() {
   echo "Making sure virtual envs are gone"
   for i in ${versions[@]}; do
@@ -80,8 +92,9 @@ for i in ${versions[@]}; do
     aborted=$((aborted+1))
     continue
   fi
+  # Actually run tests here
   echo "Running test suite"
-  python tests/run_tests.py $@
+  python tests/run_tests.py $loc
   code=$?
   counter=$((counter+1))
   codes=$((codes+code))
@@ -129,12 +142,13 @@ for i in ${version[@]}; do
     aborted=$((aborted+1))
     continue
   fi
+  # Actually run tests here
   echo "Running test suite"
-  python tests/run_tests.py $@
+  python tests/run_tests.py $loc
   code=$?
   counter=$((counter+1))
   codes=$((codes+code))
-  python tests/pandas_run.py $@
+  python tests/pandas_run.py $loc
   code=$?
   counter=$((counter+1))
   codes=$((codes+code))

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -4,3 +4,4 @@ pytest>=3.0.3
 pytest-cov>=2.4.0
 coverage>=3.7.1
 codeclimate-test-reporter>=0.2.0
+codacy-coverage>=1.3.3

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,5 +1,5 @@
 dill>=0.2.5
-fyrd>=0.6.1b3
+tabulate>=0.7.7
 pytest>=3.0.3
 pytest-cov>=2.4.0
 coverage>=3.7.1

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,6 @@
 dill>=0.2.5
 fyrd>=0.6.1b3
 pytest>=3.0.3
+pytest-cov>=2.4.0
+coverage>=3.7.1
+codeclimate-test-reporter>=0.2.0


### PR DESCRIPTION
Added a `--limited` flag to `pyenv_tests.sh` that limits the total versions tests to 2.7.10, 3.3.0, anaconda3 and anaconda2. This makes tests much faster on the slow slurm cluster.