### PR TITLE
Fix #65

### DIFF
--- a/fyrd/conf.py
+++ b/fyrd/conf.py
@@ -51,6 +51,8 @@ DEFAULTS = {
         'queue_update': 2,
         'res_time':     2700,
         'queue_type':   'auto',
+        'sbatch':       None, # Path to sbatch command
+        'qsub':         None, # Path to qsub command
         # Not implemented yet
         #  'db':           _os.path.join(CONFIG_PATH, 'db.sql'),
     },
@@ -106,7 +108,11 @@ CONF_HELP = {
             queue_type (str):   the type of queue to use, one of 'torque',
                                 'slurm', 'local', 'auto'. Default is auto to
                                 auto-detect the queue.
-            db_path (str):      where to put the job database
+            sbatch (str):       A path to the sbatch executable, only required
+                                for slurm mode if sbatch is not in the PATH.
+            qsub (str):         A path to the qsub executable, only required
+                                for torque mode if sbatch is not in the PATH.
+            db_path (str):      Where to put the job database (Not implemented)
         """
     ),
     'jobs': _dnt(

--- a/fyrd/queue.py
+++ b/fyrd/queue.py
@@ -920,8 +920,10 @@ def get_cluster_environment():
         conf.set_option('queue', 'queue_type', 'auto')
         conf_queue = 'auto'
     if conf_queue == 'auto':
-        sbatch_cmnd = conf.get_option('queue', 'sbatch', 'sbatch')
-        qsub_cmnd   = conf.get_option('queue', 'qsub', 'qsub')
+        sbatch_cmnd = conf.get_option('queue', 'sbatch')
+        qsub_cmnd   = conf.get_option('queue', 'qsub')
+        sbatch_cmnd = sbatch_cmnd if sbatch_cmnd else 'sbatch'
+        qsub_cmnd   = qsub_cmnd if qsub_cmnd else 'qsub'
         if run.which(sbatch_cmnd):
             MODE = 'slurm'
         elif run.which(qsub_cmnd):

--- a/fyrd/queue.py
+++ b/fyrd/queue.py
@@ -920,9 +920,11 @@ def get_cluster_environment():
         conf.set_option('queue', 'queue_type', 'auto')
         conf_queue = 'auto'
     if conf_queue == 'auto':
-        if run.which('sbatch'):
+        sbatch_cmnd = conf.get_option('queue', 'sbatch', 'sbatch')
+        qsub_cmnd   = conf.get_option('queue', 'qsub', 'qsub')
+        if run.which(sbatch_cmnd):
             MODE = 'slurm'
-        elif run.which('qsub'):
+        elif run.which(qsub_cmnd):
             MODE = 'torque'
         else:
             MODE = 'local'


### PR DESCRIPTION
This should allow the setting of executable paths in the config file. Passes tests everywhere, but currently failing on my slurm cluster due to timeouts (queue overworked).