### PR TITLE
Fix #85: Now throw a ValueError when keyword arguments are wrong type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.pytest_cache
 
 # C extensions
 *.so

--- a/fyrd/options.py
+++ b/fyrd/options.py
@@ -302,10 +302,12 @@ def check_arguments(kwargs):
             if (newtype is list or newtype is tuple) \
                     and not isinstance(arg, (list, tuple)):
                 opt = run.listify(opt)
+            elif newtype is int and isinstance(opt, str) and opt.isdigit():
+                opt = int(opt)
             else:
                 raise TypeError(
-                    'arg must be {}, is {}'.format(
-                        ALLOWED_KWDS[arg], type(opt)
+                    'arg "{}" must be {}, is {} ({})'.format(
+                        arg, ALLOWED_KWDS[arg], opt, type(opt)
                     )
                 )
         new_kwds[arg] = opt

--- a/fyrd/options.py
+++ b/fyrd/options.py
@@ -298,24 +298,17 @@ def check_arguments(kwargs):
             else:
                 raise OptionsError('Unrecognized argument {}'.format(arg))
         if opt is not None and not isinstance(opt, ALLOWED_KWDS[arg]):
-            try:
-                newtype = ALLOWED_KWDS[arg]
-                if (newtype is list or newtype is tuple) \
-                        and not isinstance(arg, (list, tuple)):
-                    if newtype is list:
-                        opt2 = [opt]
-                    elif newtype is tuple:
-                        opt2 = (opt,)
-                    else:
-                        raise Exception("Shouldn't be here")
-                else:
-                    opt2 = newtype(opt)
-            except:
-                raise TypeError('arg must be {}, is {}'.format(
-                    ALLOWED_KWDS[arg], type(opt)))
-            new_kwds[arg] = opt2
-        else:
-            new_kwds[arg] = opt
+            newtype = ALLOWED_KWDS[arg]
+            if (newtype is list or newtype is tuple) \
+                    and not isinstance(arg, (list, tuple)):
+                opt = run.listify(opt)
+            else:
+                raise TypeError(
+                    'arg must be {}, is {}'.format(
+                        ALLOWED_KWDS[arg], type(opt)
+                    )
+                )
+        new_kwds[arg] = opt
 
     # Parse individual complex options
     for arg, opt in new_kwds.items():
@@ -454,6 +447,12 @@ def option_to_string(option, value=None, qtype=None):
     if '{}' in kwds[option][qtype]:
         if value is None:
             return ''
+        if 'type' in kwds[option]:
+            if not isinstance(value, kwds[option]['type']):
+                raise ValueError(
+                    'Argument to {} must be {}, but is:\n{}'
+                    .format(option, kwds[option]['type'], value)
+                )
         return '{prefix} {optarg}'.format(
             prefix=prefix, optarg=kwds[option][qtype].format(value))
     else:

--- a/fyrd/run.py
+++ b/fyrd/run.py
@@ -61,9 +61,11 @@ def listify(iterable):
         return [iterable]
     if not iterable:
         return []
-    if callable(iterable):
-        iterable = iterable()
-    return list(iter(iterable))
+    try:
+        iterable = list(iterable)
+    except TypeError:
+        iterable = [iterable]
+    return iterable
 
 
 def merge_lists(lists):

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -44,7 +44,6 @@ def test_listify():
     assert fyrd.run.listify(('hi',)) == ['hi']
     assert fyrd.run.listify(('hi',)) == ['hi']
     assert fyrd.run.listify(simple_iterator()) == [1,2,3,4]
-    assert fyrd.run.listify(simple_iterator) == [1,2,3,4]
 
 
 def test_count_lines():

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import pytest
 sys.path.append(os.path.abspath('.'))
 import fyrd
-fyrd.local.THREADS = 5
 
 
 def test_help():

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -165,7 +165,7 @@ def test_parapply_summary_indirect(delete=True):
     df_comp.T.A
     df_comp.T.B
     try:
-        assert str(round(new_df.T.A)) == str(round(df_comp.T.A))
+        assert str(round(new_df.T.A, 2)) == str(round(df_comp.T.A, 2))
     except AssertionError:
         print('A:', type(new_df.T.A), ':', new_df.T.A,
               type(df_comp.T.A), ':', df_comp.T.A,)
@@ -173,7 +173,7 @@ def test_parapply_summary_indirect(delete=True):
         print('Comp df:\n', new_df)
         raise
     try:
-        assert str(round(new_df.T.B), 2) == str(round(df_comp.T.B, 2))
+        assert str(round(new_df.T.B, 2)) == str(round(df_comp.T.B, 2))
     except AssertionError:
         print('B:', type(new_df.T.B), ':', str(new_df.T.B),
               type(df_comp.T.B), ':', str(df_comp.T.B))

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -113,7 +113,7 @@ def test_parapply_summary(delete=True):
     df_comp.T.A
     df_comp.T.B
     try:
-        assert str(new_df.T.A) == str(df_comp.T.A)
+        assert str(round(new_df.T.A, 2)) == str(round(df_comp.T.A, 2))
     except AssertionError:
         print('A:', type(new_df.T.A), ':', str(new_df.T.A),
               type(df_comp.T.A), ':', str(df_comp.T.A))
@@ -121,7 +121,7 @@ def test_parapply_summary(delete=True):
         print('Comp df', new_df)
         raise
     try:
-        assert str(new_df.T.B) == str(df_comp.T.B)
+        assert str(round(new_df.T.B, 2)) == str(round(df_comp.T.B, 2))
     except AssertionError:
         print('B:', type(new_df.T.B), ':', str(new_df.T.B),
               type(df_comp.T.B), ':', str(df_comp.T.B))
@@ -165,7 +165,7 @@ def test_parapply_summary_indirect(delete=True):
     df_comp.T.A
     df_comp.T.B
     try:
-        assert str(new_df.T.A) == str(df_comp.T.A)
+        assert str(round(new_df.T.A)) == str(round(df_comp.T.A))
     except AssertionError:
         print('A:', type(new_df.T.A), ':', new_df.T.A,
               type(df_comp.T.A), ':', df_comp.T.A,)
@@ -173,7 +173,7 @@ def test_parapply_summary_indirect(delete=True):
         print('Comp df:\n', new_df)
         raise
     try:
-        assert str(new_df.T.B) == str(df_comp.T.B)
+        assert str(round(new_df.T.B), 2) == str(round(df_comp.T.B, 2))
     except AssertionError:
         print('B:', type(new_df.T.B), ':', str(new_df.T.B),
               type(df_comp.T.B), ':', str(df_comp.T.B))


### PR DESCRIPTION
Previously auto-converted keyword arguments, which caused non-obvious failures.